### PR TITLE
fix nc-time-axis package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ xarray
 cartopy
 numpy
 numba
-nc_time_axis
+nc-time-axis
 dask[distributed]
 zarr
 tqdm


### PR DESCRIPTION
although `pip` is fine with `nc_time_axis`, conda is not. therefore I suggest to use the correct package name: `nc-time-axis`